### PR TITLE
fix guardian beam rendering

### DIFF
--- a/PATCHED.md
+++ b/PATCHED.md
@@ -6,6 +6,7 @@
 * [MC-198464](https://bugs.mojang.com/browse/MC-198464) - snowy_butchers_shop_1 misplaced block
 * [MC-122627](https://bugs.mojang.com/browse/MC-122627) - Tab suggestion box has missing padding on right side
 * [MC-165381](https://bugs.mojang.com/browse/MC-165381) - Block breaking can be delayed by dropping/throwing the tool while breaking a block
+* [MC-165595](https://bugs.mojang.com/browse/MC-165595) - Guardian beam does not render when over a certain "Time" in level.dat
 
 ## Patched in snapshots
 To delete when next version comes out.

--- a/src/main/java/cc/woverflow/debugify/mixins/mc165595/GuardianEntityRendererMixin.java
+++ b/src/main/java/cc/woverflow/debugify/mixins/mc165595/GuardianEntityRendererMixin.java
@@ -1,0 +1,20 @@
+package cc.woverflow.debugify.mixins.mc165595;
+
+import net.minecraft.client.render.entity.GuardianEntityRenderer;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+/**
+ * Adapted from a Sodium PR under GPL 3 License
+ * https://github.com/AMereBagatelle/sodium-fabric/blob/guardian-beam-fix/LICENSE.txt
+ * @author AMereBagatelle
+ */
+@Mixin(GuardianEntityRenderer.class)
+public class GuardianEntityRendererMixin {
+    @Redirect(method = "render", at = @At(value = "INVOKE", target = "net/minecraft/world/World.getTime()J"))
+    private long useCorrectTime(World world) {
+        return world.getTimeOfDay();
+    }
+}

--- a/src/main/resources/debugify.mixins.json
+++ b/src/main/resources/debugify.mixins.json
@@ -10,7 +10,8 @@
     "mc165381.ClientPlayerEntityMixin",
     "mc231097.ClientPlayerEntityMixin",
     "mc234898.RealmsMainScreenMixin",
-    "mc234898.ScreenMixin"
+    "mc234898.ScreenMixin",
+    "mc165595.GuardianEntityRendererMixin"
   ],
   "mixins": [
     "mc231743.FlowerPotBlockMixin",


### PR DESCRIPTION
## Description
use time of day instead of time of world

## Related Issue(s)
Fixes #165595
