### PR TITLE
MC-80859, MC-79545, MC-14923

### DIFF
--- a/PATCHED.md
+++ b/PATCHED.md
@@ -8,6 +8,9 @@
 * [MC-165381](https://bugs.mojang.com/browse/MC-165381) - Block breaking can be delayed by dropping/throwing the tool while breaking a block
 * [MC-165595](https://bugs.mojang.com/browse/MC-165595) - Guardian beam does not render when over a certain "Time" in level.dat
 * **FABRIC** [MC-176559](https://bugs.mojang.com/browse/MC-176559) - Breaking process resets when a pickaxe enchanted with Mending mends by XP / Mending slows down breaking blocks again
+* [MC-14923](https://bugs.mojang.com/browse/MC-14923) - Players can be kicked for spamming in a singleplayer world with cheats disabled
+* [MC-79545](https://bugs.mojang.com/browse/MC-79545) - The experience bar disappears when too many levels are given to the player
+* [MC-80859](https://bugs.mojang.com/browse/MC-80859) - Starting to drag item stacks over other compatible stacks makes the latter invisible until appearance change (stack size increases)
 
 ## Patched in snapshots
 To delete when next version comes out.

--- a/common/src/main/java/cc/woverflow/debugify/mixins/mc14923/ServerPlayNetworkHandlerMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/mc14923/ServerPlayNetworkHandlerMixin.java
@@ -1,0 +1,26 @@
+package cc.woverflow.debugify.mixins.mc14923;
+
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.filter.TextStream;
+import net.minecraft.server.network.ServerPlayNetworkHandler;
+import net.minecraft.server.network.ServerPlayerEntity;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(ServerPlayNetworkHandler.class)
+public class ServerPlayNetworkHandlerMixin {
+
+    @Shadow @Final private MinecraftServer server;
+
+    @Shadow public ServerPlayerEntity player;
+
+    @Inject(method = "handleMessage", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/network/ServerPlayNetworkHandler;disconnect(Lnet/minecraft/text/Text;)V"), cancellable = true)
+    public void onMessage(TextStream.Message message, CallbackInfo ci){
+        //Check if player is host as the check it does only checks they are an op which requires it to be a host and have cheats on.
+        if (this.server.isHost(this.player.getGameProfile())) ci.cancel();
+    }
+}

--- a/common/src/main/java/cc/woverflow/debugify/mixins/mc79545/InGameHudMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/mc79545/InGameHudMixin.java
@@ -1,0 +1,19 @@
+package cc.woverflow.debugify.mixins.mc79545;
+
+import net.minecraft.client.gui.hud.InGameHud;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.util.math.MathHelper;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(InGameHud.class)
+public class InGameHudMixin {
+
+    @Redirect(method = "renderExperienceBar", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerEntity;getNextLevelExperience()I"))
+    private int getNextLevelExperience(ClientPlayerEntity instance) {
+        //Technically this only ever needs to be 1 and doesn't need to be anything else than 1 as it's only used for the if statement
+        //but just in case if Mojang in the future decide it will be used for something else then 1 just clamp it.
+        return MathHelper.clamp(instance.getNextLevelExperience(), 1, Integer.MAX_VALUE);
+    }
+}

--- a/common/src/main/java/cc/woverflow/debugify/mixins/mc80859/HandledScreenMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/mc80859/HandledScreenMixin.java
@@ -1,0 +1,22 @@
+package cc.woverflow.debugify.mixins.mc80859;
+
+import net.minecraft.client.gui.screen.ingame.HandledScreen;
+import net.minecraft.screen.slot.Slot;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+import java.util.Set;
+
+@Mixin(HandledScreen.class)
+public class HandledScreenMixin {
+
+    @Redirect(method = "drawSlot", at = @At(value = "INVOKE", target = "Ljava/util/Set;contains(Ljava/lang/Object;)Z"))
+    private boolean onQuickCraftCheck(Set<Slot> cursorDragSlots, Object slot) {
+        //If slots is size 1 then the inner method would run anyway and return so this just ignores the outer
+        //statement and lets it continue to the rendering therefore fixing the bug.
+        if (cursorDragSlots.size() == 1) return false;
+        //noinspection SuspiciousMethodCalls
+        return cursorDragSlots.contains(slot);
+    }
+}

--- a/common/src/main/resources/debugify-common.mixins.json
+++ b/common/src/main/resources/debugify-common.mixins.json
@@ -10,9 +10,12 @@
     "mc165381.ClientPlayerEntityMixin",
     "mc165595.GuardianEntityRendererMixin",
     "mc231097.ClientPlayerEntityMixin",
-    "mc234898.RealmsMainScreenMixin"
+    "mc234898.RealmsMainScreenMixin",
+    "mc80859.HandledScreenMixin",
+    "mc79545.InGameHudMixin"
   ],
   "mixins": [
+    "mc14923.ServerPlayNetworkHandlerMixin",
     "mc231743.FlowerPotBlockMixin",
     "metrics.AccessorMinecraftClient"
   ]


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
80859 - If the slots the cursor is dragging over is the size of 1 meaning its dragging over its original slot then fail the if statement and let it continue to rendering code and not returning out of the whole method and therefore not rendering at all.
79545 - Fixed xp bar disappearing due to an integer overflow by clamping the value.
14923 - Fixed getting kicked from a singleplayer world due to "spamming" by also checking if the player is the host rather than just an op as the op method requires the player to be a host and have cheats enabled.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
Fixes #80859
Fixes #79545
Fixes #14923
