### PR TITLE
Patch MC-197260

### DIFF
--- a/PATCHED.md
+++ b/PATCHED.md
@@ -29,6 +29,7 @@
 | [MC-165595](https://bugs.mojang.com/browse/MC-165595) | Guardian beam does not render when over a certain "Time" in level.dat                                                                |
 | [MC-176559](https://bugs.mojang.com/browse/MC-176559) | Breaking process resets when a pickaxe enchanted with Mending mends by XP / Mending slows down breaking blocks again *(fabric only)* |
 | [MC-183776](https://bugs.mojang.com/browse/MC-183776) | After switching gamemodes using F3+F4, you need to press F3 twice to toggle the debug screen                                         |
+| [MC-197260](https://bugs.mojang.com/browse/MC-197260) | Armor Stand renders itself and armor dark if its head is in a solid block                                                            |
 | [MC-215531](https://bugs.mojang.com/browse/MC-215531) | The carved pumpkin overlay isn't removed when switching into spectator mode                                                          |
 | [MC-217716](https://bugs.mojang.com/browse/MC-217716) | The green nausea overlay isn't removed when switching into spectator mode                                                            |
 | [MC-231097](https://bugs.mojang.com/browse/MC-231097) | Holding the "Use" button continues to slow down the player even after the used item has been dropped                                 |

--- a/common/src/main/java/cc/woverflow/debugify/mixins/client/mc197260/ArmorStandEntityRendererMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/client/mc197260/ArmorStandEntityRendererMixin.java
@@ -1,0 +1,44 @@
+package cc.woverflow.debugify.mixins.client.mc197260;
+
+import net.minecraft.client.render.LightmapTextureManager;
+import net.minecraft.client.render.VertexConsumerProvider;
+import net.minecraft.client.render.entity.ArmorStandEntityRenderer;
+import net.minecraft.client.render.entity.EntityRendererFactory;
+import net.minecraft.client.render.entity.LivingEntityRenderer;
+import net.minecraft.client.render.entity.model.ArmorStandArmorEntityModel;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.entity.decoration.ArmorStandEntity;
+import net.minecraft.network.packet.s2c.play.LightUpdateS2CPacket;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.LightType;
+import org.spongepowered.asm.mixin.Mixin;
+
+import java.util.stream.DoubleStream;
+import java.util.stream.IntStream;
+
+@Mixin(ArmorStandEntityRenderer.class)
+public abstract class ArmorStandEntityRendererMixin extends LivingEntityRenderer<ArmorStandEntity, ArmorStandArmorEntityModel> {
+
+    public ArmorStandEntityRendererMixin(EntityRendererFactory.Context ctx, ArmorStandArmorEntityModel model, float shadowRadius) {
+        super(ctx, model, shadowRadius);
+    }
+
+    /**
+     * Overrides the light level passed to the renderer, with the maximum of:
+     * * Half a block below the armor stand
+     * * Bottom of the armor stand
+     * * Top of the armor stand
+     * * Half a block above the armor stand
+     */
+    @Override
+    public void render(ArmorStandEntity livingEntity, float f, float g, MatrixStack matrixStack, VertexConsumerProvider vertexConsumerProvider, int providedLightLevel) {
+        int maxLightLevel = Math.max(providedLightLevel, DoubleStream.of(-0.5, 2, 2.5)
+                .mapToInt(operand -> {
+                    BlockPos pos = livingEntity.getBlockPos().add(0, operand, 0);
+                    return LightmapTextureManager.pack(livingEntity.world.getLightLevel(LightType.BLOCK, pos), livingEntity.world.getLightLevel(LightType.SKY, pos));
+                })
+                .max().orElse(providedLightLevel)
+        );
+        super.render(livingEntity, f, g, matrixStack, vertexConsumerProvider, maxLightLevel);
+    }
+}

--- a/common/src/main/resources/debugify-common.mixins.json
+++ b/common/src/main/resources/debugify-common.mixins.json
@@ -35,7 +35,8 @@
     "client.mc53312.VillagerResemblingModelMixin",
     "client.mc79545.InGameHudMixin",
     "client.mc80859.HandledScreenMixin",
-    "client.mc93384.LivingEntityMixin"
+    "client.mc93384.LivingEntityMixin",
+    "client.mc197260.ArmorStandEntityRendererMixin"
   ],
   "mixins": [
     "server.mc100991.FishingBobberEntityMixin",


### PR DESCRIPTION
## Description
Patch MC-197260:
Armor Stand renders itself and armor dark if its head is in a solid block.

This fix works by finding the maximum light level of the following locations:
* Half a block below the armor stand (to account for boots)
* Bottom of the armor stand (the already supplied light level)
* Top of the armor stand
* Half a block above the armor stand (to account for helmet\arms up poses)

## Related Issue(s)
Fixes #17 
