### PR TITLE
Fix MC-147605

### DIFF
--- a/common/src/main/java/cc/woverflow/debugify/mixins/client/mc147605/ClickableWidgetMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/client/mc147605/ClickableWidgetMixin.java
@@ -1,0 +1,29 @@
+package cc.woverflow.debugify.mixins.client.mc147605;
+
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.widget.ClickableWidget;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ClickableWidget.class)
+public class ClickableWidgetMixin {
+
+    @Inject(method = "setFocused", at = @At("HEAD"), cancellable = true)
+    private void setScreenFocus(boolean focused, CallbackInfo ci) {
+        if (focused && MinecraftClient.getInstance().currentScreen != null) {
+            MinecraftClient.getInstance().currentScreen.setFocused((Element) this);
+            ci.cancel();
+        }
+    }
+
+    @Inject(method = "isFocused", at = @At("HEAD"), cancellable = true)
+    private void getScreenFocus(CallbackInfoReturnable<Boolean> cir) {
+        if (MinecraftClient.getInstance().currentScreen != null) {
+            cir.setReturnValue(MinecraftClient.getInstance().currentScreen.getFocused().equals(this));
+        }
+    }
+}

--- a/common/src/main/resources/debugify-common.mixins.json
+++ b/common/src/main/resources/debugify-common.mixins.json
@@ -35,7 +35,8 @@
     "client.mc53312.VillagerResemblingModelMixin",
     "client.mc79545.InGameHudMixin",
     "client.mc80859.HandledScreenMixin",
-    "client.mc93384.LivingEntityMixin"
+    "client.mc93384.LivingEntityMixin",
+    "client.mc147605.ClickableWidgetMixin"
   ],
   "mixins": [
     "server.mc100991.FishingBobberEntityMixin",


### PR DESCRIPTION
## Description
Fix MC-147605 Text cursors can exist in multiple fields

Done by using the focus of the parent screen rather than the element focus.
