### PR TITLE
forcecloseloadingscreen has been superseded.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This mod replaces many mods and implements fixes from some others
 - **[Shift-Scroll Fix](https://www.curseforge.com/minecraft/mc-mods/shift-scroll-fix)**: Replaced
 - **[ForgetMeChunk](https://www.curseforge.com/minecraft/mc-mods/forgetmechunk)**: Replaced
 - **[ChunkSavingFix](https://www.curseforge.com/minecraft/mc-mods/chunk-saving-fix)**: Replaced
+- **[kennytvs-epic-force-close-loading-screen-mod-for-fabric](https://modrinth.com/mod/forcecloseworldloadingscreen)**: Replaced
 - **[TieFix](https://www.curseforge.com/minecraft/mc-mods/tiefix)**: Semi-replaced - some fixes have been implemented
 
 All of these mods have helped us create Debugify. We thank you very much for your effort! We made sure to follow the license of every one of these mods when creating our own version.

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -46,7 +46,8 @@
     "fastopenlinksandfolders": "*",
     "shadowedactionbar": "*",
     "shiftscrollfix": "*",
-    "chunksavingfix": "*"
+    "chunksavingfix": "*",
+    "forcecloseloadingscreen": "*"
   },
   "custom": {
     "modmenu": {


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->

Adds the forcecloseloadingscreen mod to both README and fabric.mod.json to clarify that it has been superseded and can now be replaced by debugify without too many issues.

## Related Issue(s)
<!-- List the issue(s) this PR solves -->
*(This pull request was made on request by myself, edits are welcomed)*
