### PR TITLE
[Build] Migrate to Quilt Mappings

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,29 +1,6 @@
-import com.google.gson.Gson
-import com.google.gson.JsonObject
-import java.net.URI
-import java.net.http.HttpClient
-import java.net.http.HttpRequest
-import java.net.http.HttpRequest.BodyPublishers
-import java.net.http.HttpResponse.BodyHandlers
-
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath("com.google.code.gson:gson:2.9.0")
-    }
-}
-
 plugins {
     id("architectury-plugin") version "3.4.+"
-    id("dev.architectury.loom") version "0.11.0.+" apply false
-    id("io.github.juuxel.loom-quiltflower") version "1.+" apply false
-
-    id("com.modrinth.minotaur") version "2.+"
-    id("com.matthewprenger.cursegradle") version "1.4.+" apply false
-    id("com.github.breadmoirai.github-release") version "2.+"
+    `mod-release`
 }
 
 architectury {
@@ -32,16 +9,7 @@ architectury {
 }
 
 subprojects {
-    apply(plugin = "dev.architectury.loom")
-    apply(plugin = "io.github.juuxel.loom-quiltflower")
-
-    dependencies {
-        val minecraftVersion: String by project
-        val yarnVersion: String by project
-
-        "minecraft"("com.mojang:minecraft:$minecraftVersion")
-        "mappings"("net.fabricmc:yarn:$yarnVersion:v2")
-    }
+    apply(plugin = "mc-setup")
 }
 
 allprojects {
@@ -49,9 +17,9 @@ allprojects {
     apply(plugin = "architectury-plugin")
 
     group = "cc.woverflow"
-    version = "1.7.1"
+    version = "1.8.0"
 
-    val changelog by extra { rootProject.file("changelogs/${project.version}.md").takeIf { it.exists() }?.readText() }
+    extra.set("changelog", rootProject.file("changelogs/${project.version}.md").takeIf { it.exists() }?.readText())
 
     repositories {
         mavenCentral()
@@ -65,81 +33,5 @@ allprojects {
             options.encoding = "UTF-8"
             options.release.set(17)
         }
-    }
-}
-
-tasks {
-    val publishToModrinth by registering { group = "debugify" }
-    val publishToCurseforge by registering { group = "debugify" }
-
-    val updateApiVersion by registering {
-        group = "debugify"
-        onlyIf { hasProperty("xander-api.username") && hasProperty("xander-api.password") }
-
-        val gson = Gson()
-
-        val client = HttpClient.newHttpClient()
-
-        val loginRequest = HttpRequest.newBuilder(URI.create("https://api.isxander.dev/login")).apply {
-            val json = JsonObject()
-            json.addProperty("username", findProperty("xander-api.username")?.toString())
-            json.addProperty("password", findProperty("xander-api.password")?.toString())
-            POST(BodyPublishers.ofString(gson.toJson(json)))
-            header("Content-Type", "application/json")
-        }.build()
-
-        val loginResponse = client.send(loginRequest, BodyHandlers.ofString())
-        if (loginResponse.statusCode() != 200) {
-            println("FAILED TO LOGIN TO API.ISXANDER.DEV")
-            println("STATUS CODE: ${loginResponse.statusCode()}")
-            println("RESPONSE: ${loginResponse.body()}")
-            return@registering
-        }
-
-        val loginResponseJson = gson.fromJson(loginResponse.body(), JsonObject::class.java)
-        val jwtToken = loginResponseJson.get("token").asString
-
-        val loaders = listOf("forge", "fabric")
-        val minecraftVersion: String by rootProject
-        for (loader in loaders) {
-            val newVersionRequest = HttpRequest.newBuilder(URI.create("https://api.isxander.dev/updater/new/debugify?loader=$loader&minecraft=$minecraftVersion&version=${project.version}")).apply {
-                GET()
-                header("Authorization", "Bearer $jwtToken")
-            }.build()
-
-            val response = client.send(newVersionRequest, BodyHandlers.ofString())
-        }
-    }
-
-    modrinth {
-        token.set(findProperty("modrinth.token")?.toString())
-        projectId.set("QwxR6Gcd")
-        syncBodyFrom.set(file("README.md").readText())
-    }
-
-    githubRelease {
-        token(findProperty("github.token")?.toString())
-
-        owner("W-OVERFLOW")
-        repo("Debugify")
-        tagName("${project.version}")
-        targetCommitish("1.18")
-        body(extra["changelog"].toString())
-        releaseAssets(project(":fabric").tasks["remapJar"].outputs.files, project(":forge").tasks["remapJar"].outputs.files)
-    }
-
-    register("publishDebugify") {
-        group = "debugify"
-
-        dependsOn("clean")
-
-        dependsOn(publishToModrinth)
-        dependsOn(":modrinthSyncBody")
-
-        dependsOn(publishToCurseforge)
-
-        dependsOn("githubRelease")
-
-        dependsOn(updateApiVersion)
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -4,7 +4,6 @@ plugins {
 
 repositories {
     mavenCentral()
-    mavenLocal()
     gradlePluginPortal()
     maven("https://maven.fabricmc.net")
     maven("https://maven.architectury.dev")

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    mavenLocal()
+    gradlePluginPortal()
+    maven("https://maven.fabricmc.net")
+    maven("https://maven.architectury.dev")
+    maven("https://maven.minecraftforge.net")
+    maven("https://server.bbkr.space/artifactory/libs-release")
+    maven("https://maven.quiltmc.org/repository/release")
+}
+
+dependencies {
+    fun plugin(id: String, version: String) = "$id:$id.gradle.plugin:$version"
+
+    implementation(plugin("dev.architectury.loom", "0.11.+"))
+    implementation(plugin("io.github.juuxel.loom-quiltflower", "1.7.1"))
+    implementation(plugin("org.quiltmc.quilt-mappings-on-loom", "4.+"))
+
+    implementation(plugin("com.modrinth.minotaur", "2.+"))
+    implementation(plugin("com.matthewprenger.cursegradle", "1.+"))
+    implementation(plugin("com.github.breadmoirai.github-release", "2.+"))
+    implementation("com.google.code.gson:gson:2.9.0")
+}

--- a/buildSrc/src/main/kotlin/mc-setup.gradle.kts
+++ b/buildSrc/src/main/kotlin/mc-setup.gradle.kts
@@ -1,0 +1,23 @@
+plugins {
+    id("dev.architectury.loom")
+    id("io.github.juuxel.loom-quiltflower")
+    id("org.quiltmc.quilt-mappings-on-loom")
+}
+
+loom {
+    silentMojangMappingsLicense()
+}
+
+/**
+ * have to use buildSrc for this because
+ * subprojects doesn't allow you to use loom or quiltMappings
+ */
+dependencies {
+    val minecraftVersion: String by rootProject
+
+    minecraft("com.mojang:minecraft:$minecraftVersion")
+    mappings(loom.layered {
+        officialMojangMappings()
+        addLayer(quiltMappings.mappings("org.quiltmc:quilt-mappings:$minecraftVersion+build.+:v2"))
+    })
+}

--- a/buildSrc/src/main/kotlin/mod-release.gradle.kts
+++ b/buildSrc/src/main/kotlin/mod-release.gradle.kts
@@ -1,0 +1,92 @@
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+import java.net.URI
+import java.net.http.HttpClient
+import java.net.http.HttpRequest
+import java.net.http.HttpRequest.BodyPublishers
+import java.net.http.HttpResponse
+import java.net.http.HttpResponse.BodyHandlers
+
+plugins {
+    id("com.modrinth.minotaur")
+    id("com.matthewprenger.cursegradle")
+    id("com.github.breadmoirai.github-release")
+}
+
+afterEvaluate {
+    tasks {
+        val publishToModrinth by registering { group = "debugify" }
+        val publishToCurseforge by registering { group = "debugify" }
+
+        val updateApiVersion by registering {
+            group = "debugify"
+            onlyIf { hasProperty("xander-api.username") && hasProperty("xander-api.password") }
+
+            val gson = Gson()
+
+            val client = HttpClient.newHttpClient()
+
+            val loginRequest = HttpRequest.newBuilder(URI.create("https://api.isxander.dev/login")).apply {
+                val json = JsonObject()
+                json.addProperty("username", findProperty("xander-api.username")?.toString())
+                json.addProperty("password", findProperty("xander-api.password")?.toString())
+                POST(HttpRequest.BodyPublishers.ofString(gson.toJson(json)))
+                header("Content-Type", "application/json")
+            }.build()
+
+            val loginResponse = client.send(loginRequest, HttpResponse.BodyHandlers.ofString())
+            if (loginResponse.statusCode() != 200) {
+                println("FAILED TO LOGIN TO API.ISXANDER.DEV")
+                println("STATUS CODE: ${loginResponse.statusCode()}")
+                println("RESPONSE: ${loginResponse.body()}")
+                return@registering
+            }
+
+            val loginResponseJson = gson.fromJson(loginResponse.body(), JsonObject::class.java)
+            val jwtToken = loginResponseJson.get("token").asString
+
+            val loaders = listOf("forge", "fabric")
+            val minecraftVersion: String by rootProject
+            for (loader in loaders) {
+                val newVersionRequest = HttpRequest.newBuilder(URI.create("https://api.isxander.dev/updater/new/debugify?loader=$loader&minecraft=$minecraftVersion&version=${project.version}")).apply {
+                    GET()
+                    header("Authorization", "Bearer $jwtToken")
+                }.build()
+
+                val response = client.send(newVersionRequest, HttpResponse.BodyHandlers.ofString())
+            }
+        }
+
+        register("publishDebugify") {
+            group = "debugify"
+
+            dependsOn("clean")
+
+            dependsOn(publishToModrinth)
+            dependsOn(":modrinthSyncBody")
+
+            dependsOn(publishToCurseforge)
+
+            dependsOn("githubRelease")
+
+            dependsOn(updateApiVersion)
+        }
+    }
+
+    modrinth {
+        token.set(findProperty("modrinth.token")?.toString())
+        projectId.set("QwxR6Gcd")
+        syncBodyFrom.set(file("README.md").readText())
+    }
+
+    githubRelease {
+        token(findProperty("github.token")?.toString())
+
+        owner("W-OVERFLOW")
+        repo("Debugify")
+        tagName("${project.version}")
+        targetCommitish("1.18")
+        body(extra["changelog"].toString())
+        releaseAssets(project(":fabric").tasks["remapJar"].outputs.files, project(":forge").tasks["remapJar"].outputs.files)
+    }
+}

--- a/changelogs/1.8.0.md
+++ b/changelogs/1.8.0.md
@@ -1,0 +1,3 @@
+**Misc**
+
+- Migrate to quilt mappings

--- a/common/src/main/java/cc/woverflow/debugify/mixins/client/mc111516/PlayerEntityRendererMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/client/mc111516/PlayerEntityRendererMixin.java
@@ -6,8 +6,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 /**
- * Taken from RandomPatches
- * https://github.com/TheRandomLabs/RandomPatches
+ * Taken from <a href="https://github.com/TheRandomLabs/RandomPatches">RandomPatches</a>
  * under MIT license
  *
  * Adapted to work in newer versions and a multi-loader environment

--- a/common/src/main/java/cc/woverflow/debugify/mixins/client/mc121772/MouseMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/client/mc121772/MouseMixin.java
@@ -9,8 +9,7 @@ import org.spongepowered.asm.mixin.injection.ModifyVariable;
 @Mixin(Mouse.class)
 public class MouseMixin {
     /**
-     * Taken from Shift-Scroll Fix
-     * https://github.com/nelson2tm/shift-scroll-fix
+     * Taken from <a href="https://github.com/nelson2tm/shift-scroll-fix">Shift-Scroll Fix</a>
      * under MIT license
      *
      * Adapted to work in a multi-loader environment

--- a/common/src/main/java/cc/woverflow/debugify/mixins/client/mc183776/KeyboardMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/client/mc183776/KeyboardMixin.java
@@ -8,7 +8,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(Keyboard.class)
 public class KeyboardMixin {
-    @Inject(method = "processF3", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setScreen(Lnet/minecraft/client/gui/screen/Screen;)V", shift = At.Shift.AFTER), cancellable = true)
+    @Inject(method = "processDebugKeys", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/MinecraftClient;setScreen(Lnet/minecraft/client/gui/screen/Screen;)V", shift = At.Shift.AFTER), cancellable = true)
     private void onSetGamemodeSelectionScreen(int key, CallbackInfoReturnable<Boolean> cir) {
         cir.setReturnValue(false);
     }

--- a/common/src/main/java/cc/woverflow/debugify/mixins/client/mc234898/RealmsMainScreenMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/client/mc234898/RealmsMainScreenMixin.java
@@ -36,7 +36,7 @@ public abstract class RealmsMainScreenMixin extends Screen {
      * avoid checks to see if realms trial
      * is available as it's a faulty check
      */
-    @Inject(method = "method_24989", at = @At("HEAD"), cancellable = true)
+    @Inject(method = "m_hsfgqbkv", at = @At("HEAD"), cancellable = true)
     private void onPressTrialButton(ButtonWidget button, CallbackInfo ci) {
         Util.getOperatingSystem().open("https://aka.ms/startjavarealmstrial");
         this.client.setScreen(this.lastScreen);

--- a/common/src/main/java/cc/woverflow/debugify/mixins/client/mc249059/DownloadingTerrainScreenMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/client/mc249059/DownloadingTerrainScreenMixin.java
@@ -9,14 +9,14 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(DownloadingTerrainScreen.class)
 public class DownloadingTerrainScreenMixin {
-    @Shadow private boolean closeOnNextTick;
+    @Shadow private boolean oneTickSkipped;
 
     /**
      * for some reason mojang waits 2 seconds even after
      * the terrain is ready (guessing to avoid lag of spawning entities?)
      */
-    @Inject(method = "setReady", at = @At("HEAD"))
+    @Inject(method = "setLoadingPacketsReceived", at = @At("HEAD"))
     private void onReady(CallbackInfo ci) {
-        closeOnNextTick = true;
+        oneTickSkipped = true;
     }
 }

--- a/common/src/main/java/cc/woverflow/debugify/mixins/client/mc53312/VillagerResemblingModelMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/client/mc53312/VillagerResemblingModelMixin.java
@@ -6,8 +6,7 @@ import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
 
 /**
- * Taken from RandomPatches
- * https://github.com/TheRandomLabs/RandomPatches
+ * Taken from <a href="https://github.com/TheRandomLabs/RandomPatches">RandomPatches</a>
  * under MIT license
  *
  * Adapted to work in newer versions and a multi-loader environment

--- a/common/src/main/java/cc/woverflow/debugify/mixins/server/mc160095/CactusBlockMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/server/mc160095/CactusBlockMixin.java
@@ -17,7 +17,7 @@ public class CactusBlockMixin {
         BlockState state = instance.getBlockState(pos);
         //If it is a moving piston we check the block its moving not the moving piston block itself.
         if (state.isOf(Blocks.MOVING_PISTON) && instance.getBlockEntity(pos) instanceof PistonBlockEntity pistonBlock) {
-            return pistonBlock.getPushedBlock();
+            return pistonBlock.getMovedBlockState();
         }
         return state;
     }

--- a/common/src/main/java/cc/woverflow/debugify/mixins/server/mc224729/ThreadedAnvilChunkStorageMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/server/mc224729/ThreadedAnvilChunkStorageMixin.java
@@ -23,7 +23,7 @@ public class ThreadedAnvilChunkStorageMixin {
         return (c) -> predicate.test(c) || c instanceof ProtoChunk;
     }
 
-    @ModifyExpressionValue(method = "saveChunkIfNeeded(Lnet/minecraft/server/world/ChunkHolder;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;isAccessible()Z"))
+    @ModifyExpressionValue(method = "saveChunkIfNeeded", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;isAccessible()Z"))
     private boolean alwaysAccessibleChunkSave(boolean accessible) {
         return true;
     }

--- a/common/src/main/java/cc/woverflow/debugify/mixins/server/mc224729/ThreadedAnvilChunkStorageMixin.java
+++ b/common/src/main/java/cc/woverflow/debugify/mixins/server/mc224729/ThreadedAnvilChunkStorageMixin.java
@@ -23,7 +23,7 @@ public class ThreadedAnvilChunkStorageMixin {
         return (c) -> predicate.test(c) || c instanceof ProtoChunk;
     }
 
-    @ModifyExpressionValue(method = "save(Lnet/minecraft/server/world/ChunkHolder;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;isAccessible()Z"))
+    @ModifyExpressionValue(method = "saveChunkIfNeeded(Lnet/minecraft/server/world/ChunkHolder;)Z", at = @At(value = "INVOKE", target = "Lnet/minecraft/server/world/ChunkHolder;isAccessible()Z"))
     private boolean alwaysAccessibleChunkSave(boolean accessible) {
         return true;
     }

--- a/common/src/main/resources/debugify-common.mixins.json
+++ b/common/src/main/resources/debugify-common.mixins.json
@@ -19,7 +19,9 @@
     "client.mc140646.TextFieldWidgetMixin",
     "client.mc145748.SliderWidgetMixin",
     "client.mc145929.InGameHudMixin",
+    "client.mc147605.AbstractParentElementMixin",
     "client.mc147605.ClickableWidgetMixin",
+    "client.mc147605.TextFieldWidgetMixin",
     "client.mc148149.OperatingSystemMixin",
     "client.mc151412.AddServerScreenMixin",
     "client.mc159163.ClientPlayNetworkHandlerMixin",
@@ -35,6 +37,7 @@
     "client.mc234898.RealmsMainScreenMixin",
     "client.mc249021.RealmsMainScreenMixin",
     "client.mc249059.DownloadingTerrainScreenMixin",
+    "client.mc4490.FishingBobberEntityRendererMixin",
     "client.mc46766.MinecraftClientMixin",
     "client.mc53312.VillagerResemblingModelMixin",
     "client.mc79545.InGameHudMixin",
@@ -42,8 +45,6 @@
     "client.mc93384.LivingEntityMixin"
   ],
   "mixins": [
-    "client.mc147605.AbstractParentElementMixin",
-    "client.mc147605.TextFieldWidgetMixin",
     "server.mc100991.FishingBobberEntityMixin",
     "server.mc100991.ProjectileEntityMixin",
     "server.mc119417.ServerPlayerEntityMixin",

--- a/forge/build.gradle.kts
+++ b/forge/build.gradle.kts
@@ -94,10 +94,6 @@ components["java"].withGroovyBuilder {
     }
 }
 
-quiltflower {
-    addToRuntimeClasspath.set(true)
-}
-
 val minecraftVersion: String by rootProject
 
 modrinth {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,6 @@
 org.gradle.jvmargs=-Xmx2G
 
-# https://fabricmc.net/develop
 minecraftVersion=1.18.2
-yarnVersion=1.18.2+build.+
 fabricLoaderVersion=0.13.+
 forgeVersion=40.0.+
 


### PR DESCRIPTION
## Description
Yarn has come to be quite unreliable with many just wrong mappings. Migrating to Quilt could stop this.

Currently, I have backed Quilt with Mojmap as QM's completeness is quite poor.

## Concerns
The PR in its current state is quite complex due to the use of `buildSrc`. This is because configuring mappings within `subprojects` does not allow for the use of `quiltMappings` or `loom.layered {}` both required to move away from yarn.
