### PR TITLE
Replaced No Tlemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This mod replaces many mods and implements fixes from some others
 - **[ForgetMeChunk](https://www.curseforge.com/minecraft/mc-mods/forgetmechunk)**: Replaced
 - **[ChunkSavingFix](https://www.curseforge.com/minecraft/mc-mods/chunk-saving-fix)**: Replaced
 - **[force-close-world-loading-screen](https://modrinth.com/mod/forcecloseworldloadingscreen)**: Replaced
+- **[No Telemetry](https://www.curseforge.com/minecraft/mc-mods/no-telemetry/)**: Replaced
 - **[TieFix](https://www.curseforge.com/minecraft/mc-mods/tiefix)**: Semi-replaced - some fixes have been implemented
 
 All of these mods have helped us create Debugify. We thank you very much for your effort! We made sure to follow the license of every one of these mods when creating our own version.


### PR DESCRIPTION
Question: Isn't TieFix completely replaced by Debugify?

## Description
Added No Telemetry to the replaced mods (inside README.md)

## Related Issue(s)
None
